### PR TITLE
fix: use /p/internalHref href url #1

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -56,7 +56,7 @@ exports.aceCreateDomLine = function(name, context){
   
   if (internalHref)
   {
-    var url = (inTimeslider ? '../' : './') + internalHref;
+    var url = `/p/${internalHref}`;
     var modifier = {
       extraOpenTags: '<a href="' + Security.escapeHTMLAttribute(url) +'">',
       extraCloseTags: '</a>',


### PR DESCRIPTION
Hi,

I've created this commit to solve #1 issue.

I'm not using `inTimeslider`, and I havn't tested it in Timeslider UI, so it may be buggy but it solves the issue on the main UI.

Thanks,

Alex